### PR TITLE
avoid description text overlaps with sidebar.

### DIFF
--- a/app/assets/stylesheets/home.css.scss
+++ b/app/assets/stylesheets/home.css.scss
@@ -23,7 +23,7 @@
       }
 
       > .content {
-        margin: 0 -20px 0 15px; /* negative indent the amount of the padding to maintain the grid system */
+        margin: 0 -5px 0 15px; /* negative indent the amount of the padding to maintain the grid system */
         -webkit-border-radius: 0 0 6px 6px;
         -moz-border-radius: 0 0 6px 6px;
         border-radius: 0 0 6px 6px;


### PR DESCRIPTION
when I go to http://railscasts-china.com/, I see the description text overlaps with sidebar. See bellow screenshot:

![Snip20130424_1](https://f.cloud.github.com/assets/1198651/419534/4a355400-acd2-11e2-9e83-282b37c15a3d.png)

Seems need to adjust the CSS(margin-right) of .content class
